### PR TITLE
Fix README.md api_endpoint attribute in stns::client

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ default['stns']['server']['groups'] = [
     <th>Default</th>
   </tr>
   <tr>
-    <td><tt>['stns']['client']['api_end_point']</tt></td>
-    <td>string array</td>
+    <td><tt>['stns']['client']['api_endpoint']</tt></td>
+    <td>string</td>
     <td>stns end point</td>
-    <td><tt>[http://localhost:1104/v2]</tt></td>
+    <td><tt>http://localhost:1104/v2</tt></td>
   </tr>
   <tr>
     <td><tt>['stns']['client']['user']</tt></td>


### PR DESCRIPTION
- `api_endpoint` attribute key name
- `api_endpoint` attribute type from `string array` to `string`

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5629074/48962976-792a9200-efcc-11e8-9047-2953b61dbcd0.png) | ![image](https://user-images.githubusercontent.com/5629074/48962983-8fd0e900-efcc-11e8-8dc8-15dd91990ec1.png) |

